### PR TITLE
Sanitize series key to prevent path traversal

### DIFF
--- a/api/app/downloader.py
+++ b/api/app/downloader.py
@@ -8,7 +8,18 @@ from typing import List, Dict
 # TODO: Replace with real image fetch logic for Comick chapters.
 
 def download_chapters(download_dir: Path, series_key: str, chapters: List[Dict]):
-    series_dir = download_dir / series_key
+    """Create placeholder CBZ files for the requested chapters.
+
+    A series key might originate from user input or an external API.  To avoid
+    path traversal, only the final path segment is used when constructing the
+    directory for the series.
+    """
+
+    base_dir = download_dir.resolve()
+    series_dir = (base_dir / Path(series_key).name).resolve()
+    if not series_dir.is_relative_to(base_dir):
+        raise ValueError("Invalid series key")
+
     series_dir.mkdir(parents=True, exist_ok=True)
     created = []
     for c in chapters:

--- a/api/tests/test_downloader.py
+++ b/api/tests/test_downloader.py
@@ -22,3 +22,12 @@ def test_download_chapters_creates_cbz_with_readme():
                 with z.open("README.txt") as f:
                     content = f.read().decode()
                     assert chap["title"] in content
+
+
+def test_download_chapters_sanitizes_series_key():
+    chapters = [{"num": "1", "title": "One"}]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        created = download_chapters(Path(tmpdir), "../evil", chapters)
+        assert len(created) == 1
+        p = Path(created[0]).resolve()
+        assert p.is_relative_to(Path(tmpdir).resolve())


### PR DESCRIPTION
## Summary
- Sanitize series key in downloader to avoid directory traversal and validate input
- Add test ensuring generated chapters stay within the download directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c7958a54832fb6b54701124bcd86